### PR TITLE
Extends `toInterfaceString` to sub-interfaces

### DIFF
--- a/src/build_types/helpers.test.ts
+++ b/src/build_types/helpers.test.ts
@@ -1,48 +1,62 @@
+import { EcsFieldSpec } from '../types';
 import { Helpers } from './helpers';
 
 describe('Helpers', () => {
-  let tester: any;
+  let tester: Helpers;
+  
   beforeEach(() => {
     tester = new Helpers();
-  })
-  it('exists', () => {
-    expect(tester).toBeDefined();
   });
   
   it('builds a root Ecs exported interface name', () => {
-    const ti = {name: 'my_interface', isRootLevel: true, exportInterface: true};
-    const actual = tester.buildInterfaceName(ti.name,ti.isRootLevel, ti.exportInterface);
+    const actual = tester.buildInterfaceName('my_interface', true);
     expect(actual).toMatchInlineSnapshot(`
 "export interface EcsMyInterface {
 "
-`)
-  });
-  
-  it('builds a plain explorted interface name', () => {
-    const ti = {name: 'my_interface', isRootLevel: false, exportInterface: true};
-    const actual = tester.buildInterfaceName(ti.name, ti.isRootLevel, ti.exportInterface);
-    expect(actual).toMatchInlineSnapshot(`
-"export interface MyInterface {
-"
-`)
+`);
   });
   
   it('builds a plain non-exported interface name', () => {
-    const ti = {name: 'my_interface', isRootLevel: false, exportInterface: false};
-    const actual = tester.buildInterfaceName(ti.name, ti.isRootLevel, ti.exportInterface);
+    const actual = tester.buildInterfaceName('my_interface', false);
     expect(actual).toMatchInlineSnapshot(`
 "interface MyInterface {
+"
+`);
+  });
+  
+  it('formats a multiline description string', () => {
+    const testDesc =  "Some realy long\nmultiline description for a property.";
+    
+    expect(tester.buildDescription(testDesc)).toMatchInlineSnapshot(`
+"// Some realy long
+// multiline description for a property."
+`);
+  });
+  
+  it('builds an interface property string', () => {
+    expect(tester.buildInterfacePropString('my_interface')).toMatchInlineSnapshot(`
+"my_interface?: MyInterface;
 "
 `)
   });
   
-  it('formats a multiline description string', () => {
-    const testDesc =  "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.\nExamples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.";
-    
-    expect(tester.buildDescription(testDesc)).toMatchInlineSnapshot(`
-      "// The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
-      // Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken."
-      `
-    )
+  it('builds a field property string', () => {
+    const testFieldSpec: EcsFieldSpec = {
+      name: 'my_prop',
+      type: 'text',
+      required: true,
+      dashed_name: 'dashed_name',
+      description: 'description',
+      example: 'example',
+      flat_name: 'flat-name',
+      level: 'core',
+      normalize: [],
+      short: 'my-prop',
+      ignore_above: 0
+    }
+    expect(tester.buildFieldPropString(testFieldSpec)).toMatchInlineSnapshot(`
+"my_prop?: string;
+"
+`)
   });
-})
+});

--- a/src/build_types/helpers.ts
+++ b/src/build_types/helpers.ts
@@ -1,21 +1,32 @@
+import { EcsFieldSpec } from '../types';
+import { convertType } from './convert_type';
+
 export class Helpers {
-  
   private static asCamelCase = (str: string) => str.replace(/(\.|_)([a-z])/g, (g:string) => g[`1`].toUpperCase());
   
   public static asPascalCase = (str: string) => {
     return Helpers.asCamelCase(str).charAt(0).toUpperCase() + Helpers.asCamelCase(str).slice(1)
-  }
+  };
   
-  public buildInterfaceName(name: string, isRootLevel: boolean = false, exportInterface = false): string {
-    let interfaceNameString = isRootLevel ? `interface Ecs${Helpers.asPascalCase(name)} {\n` : `interface ${Helpers.asPascalCase(name)} {\n`;
-    if (exportInterface === true) {
-      return `export ${interfaceNameString}`
-    } else {
-      return interfaceNameString;
-    }
-  }
+  public buildInterfaceName(name: string, exportInterface = false): string {
+    return exportInterface 
+      ? `export interface Ecs${Helpers.asPascalCase(name)} {\n` 
+      : `interface ${Helpers.asPascalCase(name)} {\n`;
+  };
   
   public buildDescription(desc: string): string {
-    return desc.split('\n').map((line: string) => `// ${line}`).join('\n');
-  }
-}
+    return desc.split('\n')
+      .map((line: string) => `// ${line}`)
+      .join('\n');
+  };
+  
+  public buildInterfacePropString(name: string): string {
+    return `${name}?: ${Helpers.asPascalCase(name)};\n`
+  };
+  
+  public buildFieldPropString(value: EcsFieldSpec) {
+    const { required, name, type } = value;
+    const opt = required === true ? `?` : ``;
+    return `${name}${opt}: ${convertType(type)};\n`;
+  };
+};

--- a/src/build_types/interface.test.ts
+++ b/src/build_types/interface.test.ts
@@ -74,7 +74,11 @@ Interface {
 "// main interface
     export interface EcsMain {
 myinterface_property?: MyinterfaceProperty;
-    }"
+}
+// My interface property description
+    interface MyinterfaceProperty {
+}
+"
 `)
   });
   
@@ -116,22 +120,12 @@ Interface {
     expect(intAsString).toMatchInlineSnapshot(`
 "// main interface
     export interface EcsMain {
-test_prop?: string
-    }"
+test_prop?: string;
+}
+"
 `)
   });
-  it.only('writes all dedicated interfaces', () => {
-  /**
-    export interface EcsCloud {
-      availability_zone?: string;
-      account?: Account;
-    }
-      interface Account {
-        id?: string,
-        name?: string
-      }
-    } 
-*/
+  it('writes all dedicated interfaces', () => {
     const cloudInterface = new Interface({ name: 'cloud', description: 'cloud description' });
     const availabilityZone: EcsFieldSpec = {
       dashed_name: 'cloud-availability-zone',
@@ -153,7 +147,7 @@ test_prop?: string
       example: '666777888999',
       flat_name: 'cloud.account.id',
       level: 'extended',
-      name: 'account.id',
+      name: 'id',
       normalize: [],
       required: false,
       short: 'The cloud account or organization id.',
@@ -173,12 +167,12 @@ test_prop?: string
     export interface EcsCloud {
 availability_zone: string;
 account?: Account;
-
-    }// account description
-    interface EcsAccount {
-account.id: string;
-
-    }"
+}
+// account description
+    interface Account {
+id: string;
+}
+"
 `)
   });
 });

--- a/src/build_types/interface.ts
+++ b/src/build_types/interface.ts
@@ -1,4 +1,3 @@
-import { convertType } from './convert_type';
 import { Helpers } from './helpers';
 import { EcsFieldSpec } from '../types';
 
@@ -17,28 +16,26 @@ export class Interface {
     this.str = ``;
     this.otherInterfaces = [];
   };
-  
+
   addProperty(name: string, value: EcsFieldSpec | Interface): void {
     if (!this.properties.hasOwnProperty(`${name}`)) {
       this.properties[name] = value;
     }
   };
-  
+
   toInterfaceString(exportInterface: boolean): string {
     this.str += h.buildDescription(this.description);
     this.str += `
-    ${h.buildInterfaceName(this.name, true, exportInterface)}`
+    ${h.buildInterfaceName(this.name, exportInterface)}`
     for (const [key, value] of Object.entries(this.properties)) {
       if (this.properties[key] instanceof Interface) {
-        this.str += `${value.name}?: ${Helpers.asPascalCase(value.name)};\n`; 
+        this.str += h.buildInterfacePropString(value.name); 
         this.otherInterfaces.push(value as Interface);
       } else {
-        const opt = ((value as EcsFieldSpec).required === true) ? `?` : ``;
-        this.str += `${value?.name}${opt}: ${convertType((value as EcsFieldSpec)?.type)};\n`
+        this.str += h.buildFieldPropString(value as EcsFieldSpec);
       }
     }
-    this.str += `
-    }`
+    this.str += `}\n`
     this.otherInterfaces.forEach((int: Interface) => this.str += int.toInterfaceString(false))
     return this.str;
   };


### PR DESCRIPTION
This PR extends the `toInterfaceString` method of the `Interface` class to also handle nested Interfaces.
e.g.:
```
// EcsA description
    export interface EcsA {
		prop_a: "string";
		propb?: Bprop;
		}
// bprop description
    interface Bprop {
		id: "string";
	}
"
```
This PR also adds 2 new helper class methods to create the Interface prop strings and the EcsField type prop strings as represented in the final ts