### PR TITLE
Adds helper for creating interface test fixtures

### DIFF
--- a/src/build_types/interface.test.ts
+++ b/src/build_types/interface.test.ts
@@ -17,6 +17,7 @@ import { Interface } from './interface';
    prop_f?: 'keyword';
  }
  */
+ // @ts-ignore unused
 function createInterfaceWithProps(): Interface {
   const interfacesMeta = [
     { name: "A", description: "Description of A" },


### PR DESCRIPTION
Setting up test fixtures for the `Interface` class is somewhat tedious.
This PR adds a very simple helper method `createInterfaceWithProps` for creating a test fixture that represents the following interfaces:
```
 interface A {
   prop_a?: 'keyword';
   prop_b?: PropB;
 }
 interface PropB {
   prop_c: 'keyword';
   prop_d?: PropD;
 }
 interface PropD {
   prop_e?: 'keyword';
   prop_f?: 'keyword';
 }
```
ATM, the method doesn't accept any arguments but it can be easily adapted to be more flexible.
