### PR TITLE
Update initial parsing logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Automatically generated TypeScript type definitions for the
 1. `yarn build`: Runs `tsc`
 1. `yarn dev`: Runs `tsc` and watches for changes
 1. `yarn test`: Runs unit tests with `jest`
-1. `yarn generate-ecs-types`: Generates a ts file in `generated/ecs.ts`
+1. `yarn generate-ecs-types`: Generates ts files in `generated/ecs.ts`
 

--- a/generated/agent.ts
+++ b/generated/agent.ts
@@ -1,0 +1,15 @@
+
+export interface EcsAgent {
+  build?: Build;
+  ephemeral_id?: string;
+  id?: string;
+  name?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Build {
+  original?: string;
+}
+

--- a/generated/as.ts
+++ b/generated/as.ts
@@ -1,0 +1,11 @@
+
+export interface EcsAs {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+

--- a/generated/client.ts
+++ b/generated/client.ts
@@ -1,0 +1,69 @@
+
+export interface EcsClient {
+  address?: string;
+  as?: As;
+  bytes?: number;
+  domain?: string;
+  geo?: Geo;
+  ip?: string;
+  mac?: string;
+  nat?: Nat;
+  packets?: number;
+  port?: number;
+  registered_domain?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  user?: User;
+}
+
+
+interface As {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Nat {
+  ip?: string;
+  port?: number;
+}
+
+
+interface User {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/cloud.ts
+++ b/generated/cloud.ts
@@ -1,0 +1,122 @@
+
+export interface EcsCloud {
+  account?: Account;
+  availability_zone?: string;
+  instance?: Instance;
+  machine?: Machine;
+  origin?: Origin;
+  project?: Project;
+  provider?: string;
+  region?: string;
+  service?: Service;
+  target?: Target;
+}
+
+
+interface Account {
+  id?: string;
+  name?: string;
+}
+
+
+interface Instance {
+  id?: string;
+  name?: string;
+}
+
+
+interface Machine {
+  type?: string;
+}
+
+
+interface Origin {
+  account?: Account;
+  availability_zone?: string;
+  instance?: Instance;
+  machine?: Machine;
+  project?: Project;
+  provider?: string;
+  region?: string;
+  service?: Service;
+}
+
+
+interface Account {
+  id?: string;
+  name?: string;
+}
+
+
+interface Instance {
+  id?: string;
+  name?: string;
+}
+
+
+interface Machine {
+  type?: string;
+}
+
+
+interface Project {
+  id?: string;
+  name?: string;
+}
+
+
+interface Service {
+  name?: string;
+}
+
+
+interface Project {
+  id?: string;
+  name?: string;
+}
+
+
+interface Service {
+  name?: string;
+}
+
+
+interface Target {
+  account?: Account;
+  availability_zone?: string;
+  instance?: Instance;
+  machine?: Machine;
+  project?: Project;
+  provider?: string;
+  region?: string;
+  service?: Service;
+}
+
+
+interface Account {
+  id?: string;
+  name?: string;
+}
+
+
+interface Instance {
+  id?: string;
+  name?: string;
+}
+
+
+interface Machine {
+  type?: string;
+}
+
+
+interface Project {
+  id?: string;
+  name?: string;
+}
+
+
+interface Service {
+  name?: string;
+}
+

--- a/generated/code_signature.ts
+++ b/generated/code_signature.ts
@@ -1,0 +1,13 @@
+
+export interface EcsCodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+

--- a/generated/container.ts
+++ b/generated/container.ts
@@ -1,0 +1,15 @@
+
+export interface EcsContainer {
+  id?: string;
+  image?: Image;
+  labels?: Record<string, unknown>;
+  name?: string;
+  runtime?: string;
+}
+
+
+interface Image {
+  name?: string;
+  tag?: string;
+}
+

--- a/generated/data_stream.ts
+++ b/generated/data_stream.ts
@@ -1,0 +1,7 @@
+
+export interface EcsDataStream {
+  dataset?: string;
+  namespace?: string;
+  type?: string;
+}
+

--- a/generated/destination.ts
+++ b/generated/destination.ts
@@ -1,0 +1,69 @@
+
+export interface EcsDestination {
+  address?: string;
+  as?: As;
+  bytes?: number;
+  domain?: string;
+  geo?: Geo;
+  ip?: string;
+  mac?: string;
+  nat?: Nat;
+  packets?: number;
+  port?: number;
+  registered_domain?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  user?: User;
+}
+
+
+interface As {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Nat {
+  ip?: string;
+  port?: number;
+}
+
+
+interface User {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/dll.ts
+++ b/generated/dll.ts
@@ -1,0 +1,45 @@
+
+export interface EcsDll {
+  code_signature?: CodeSignature;
+  hash?: Hash;
+  name?: string;
+  path?: string;
+  pe?: Pe;
+}
+
+
+interface CodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+
+
+interface Pe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+

--- a/generated/dns.ts
+++ b/generated/dns.ts
@@ -1,0 +1,22 @@
+
+export interface EcsDns {
+  answers?: Record<string, unknown>;
+  header_flags?: string;
+  id?: string;
+  op_code?: string;
+  question?: Question;
+  resolved_ip?: string;
+  response_code?: string;
+  type?: string;
+}
+
+
+interface Question {
+  class?: string;
+  name?: string;
+  registered_domain?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  type?: string;
+}
+

--- a/generated/ecs.ts
+++ b/generated/ecs.ts
@@ -1,8 +1,5 @@
-// ECS types
 
-// The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
-// Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
-export interface Test {
-  name?: string;
+export interface EcsEcs {
+  version: string;
 }
-  
+

--- a/generated/elf.ts
+++ b/generated/elf.ts
@@ -1,0 +1,27 @@
+
+export interface EcsElf {
+  architecture?: string;
+  byte_order?: string;
+  cpu_type?: string;
+  creation_date?: string;
+  exports?: Record<string, unknown>;
+  header?: Header;
+  imports?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  segments?: Record<string, unknown>;
+  shared_libraries?: string;
+  telfhash?: string;
+}
+
+
+interface Header {
+  abi_version?: string;
+  class?: string;
+  data?: string;
+  entrypoint?: number;
+  object_version?: string;
+  os_abi?: string;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/email.ts
+++ b/generated/email.ts
@@ -1,0 +1,49 @@
+
+export interface EcsEmail {
+  attachments?: Record<string, unknown>;
+  bcc?: Bcc;
+  cc?: Cc;
+  content_type?: string;
+  delivery_timestamp?: string;
+  direction?: string;
+  from?: From;
+  local_id?: string;
+  message_id?: string;
+  origination_timestamp?: string;
+  reply_to?: ReplyTo;
+  sender?: Sender;
+  subject?: string;
+  to?: To;
+  x_mailer?: string;
+}
+
+
+interface Bcc {
+  address?: string;
+}
+
+
+interface Cc {
+  address?: string;
+}
+
+
+interface From {
+  address?: string;
+}
+
+
+interface ReplyTo {
+  address?: string;
+}
+
+
+interface Sender {
+  address?: string;
+}
+
+
+interface To {
+  address?: string;
+}
+

--- a/generated/error.ts
+++ b/generated/error.ts
@@ -1,0 +1,9 @@
+
+export interface EcsError {
+  code?: string;
+  id?: string;
+  message?: string;
+  stack_trace?: string;
+  type?: string;
+}
+

--- a/generated/event.ts
+++ b/generated/event.ts
@@ -1,0 +1,30 @@
+
+export interface EcsEvent {
+  action?: string;
+  agent_id_status?: string;
+  category?: string;
+  code?: string;
+  created?: string;
+  dataset?: string;
+  duration?: number;
+  end?: string;
+  hash?: string;
+  id?: string;
+  ingested?: string;
+  kind?: string;
+  module?: string;
+  original?: string;
+  outcome?: string;
+  provider?: string;
+  reason?: string;
+  reference?: string;
+  risk_score?: number;
+  risk_score_norm?: number;
+  sequence?: number;
+  severity?: number;
+  start?: string;
+  timezone?: string;
+  type?: string;
+  url?: string;
+}
+

--- a/generated/faas.ts
+++ b/generated/faas.ts
@@ -1,0 +1,7 @@
+
+export interface EcsFaas {
+  coldstart?: boolean;
+  execution?: string;
+  trigger?: Record<string, unknown>;
+}
+

--- a/generated/file.ts
+++ b/generated/file.ts
@@ -1,0 +1,132 @@
+
+export interface EcsFile {
+  accessed?: string;
+  attributes?: string;
+  code_signature?: CodeSignature;
+  created?: string;
+  ctime?: string;
+  device?: string;
+  directory?: string;
+  drive_letter?: string;
+  elf?: Elf;
+  extension?: string;
+  fork_name?: string;
+  gid?: string;
+  group?: string;
+  hash?: Hash;
+  inode?: string;
+  mime_type?: string;
+  mode?: string;
+  mtime?: string;
+  name?: string;
+  owner?: string;
+  path?: string;
+  pe?: Pe;
+  size?: number;
+  target_path?: string;
+  type?: string;
+  uid?: string;
+  x509?: X509;
+}
+
+
+interface CodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+
+
+interface Elf {
+  architecture?: string;
+  byte_order?: string;
+  cpu_type?: string;
+  creation_date?: string;
+  exports?: Record<string, unknown>;
+  header?: Header;
+  imports?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  segments?: Record<string, unknown>;
+  shared_libraries?: string;
+  telfhash?: string;
+}
+
+
+interface Header {
+  abi_version?: string;
+  class?: string;
+  data?: string;
+  entrypoint?: number;
+  object_version?: string;
+  os_abi?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+
+
+interface Pe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+
+
+interface X509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+

--- a/generated/geo.ts
+++ b/generated/geo.ts
@@ -1,0 +1,15 @@
+
+export interface EcsGeo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+

--- a/generated/group.ts
+++ b/generated/group.ts
@@ -1,0 +1,7 @@
+
+export interface EcsGroup {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/hash.ts
+++ b/generated/hash.ts
@@ -1,0 +1,11 @@
+
+export interface EcsHash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+

--- a/generated/host.ts
+++ b/generated/host.ts
@@ -1,0 +1,83 @@
+
+export interface EcsHost {
+  architecture?: string;
+  cpu?: Cpu;
+  disk?: Disk;
+  domain?: string;
+  geo?: Geo;
+  hostname?: string;
+  id?: string;
+  ip?: string;
+  mac?: string;
+  name?: string;
+  network?: Network;
+  os?: Os;
+  type?: string;
+  uptime?: number;
+}
+
+
+interface Cpu {
+  usage?: number;
+}
+
+
+interface Disk {
+  read?: Read;
+  write?: Write;
+}
+
+
+interface Read {
+  bytes?: number;
+}
+
+
+interface Write {
+  bytes?: number;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Network {
+  egress?: Egress;
+  ingress?: Ingress;
+}
+
+
+interface Egress {
+  bytes?: number;
+  packets?: number;
+}
+
+
+interface Ingress {
+  bytes?: number;
+  packets?: number;
+}
+
+
+interface Os {
+  family?: string;
+  full?: string;
+  kernel?: string;
+  name?: string;
+  platform?: string;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/http.ts
+++ b/generated/http.ts
@@ -1,0 +1,37 @@
+
+export interface EcsHttp {
+  request?: Request;
+  response?: Response;
+  version?: string;
+}
+
+
+interface Request {
+  body?: Body;
+  bytes?: number;
+  id?: string;
+  method?: string;
+  mime_type?: string;
+  referrer?: string;
+}
+
+
+interface Body {
+  bytes?: number;
+  content?: string;
+}
+
+
+interface Response {
+  body?: Body;
+  bytes?: number;
+  mime_type?: string;
+  status_code?: number;
+}
+
+
+interface Body {
+  bytes?: number;
+  content?: string;
+}
+

--- a/generated/index.ts
+++ b/generated/index.ts
@@ -1,1 +1,0 @@
-export * from './ecs';

--- a/generated/interface.ts
+++ b/generated/interface.ts
@@ -1,0 +1,7 @@
+
+export interface EcsInterface {
+  alias?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/log.ts
+++ b/generated/log.ts
@@ -1,0 +1,26 @@
+
+export interface EcsLog {
+  file?: File;
+  level?: string;
+  logger?: string;
+  origin?: Origin;
+  syslog?: Record<string, unknown>;
+}
+
+
+interface File {
+  path?: string;
+}
+
+
+interface Origin {
+  file?: File;
+  function?: string;
+}
+
+
+interface File {
+  line?: number;
+  name?: string;
+}
+

--- a/generated/network.ts
+++ b/generated/network.ts
@@ -1,0 +1,23 @@
+
+export interface EcsNetwork {
+  application?: string;
+  bytes?: number;
+  community_id?: string;
+  direction?: string;
+  forwarded_ip?: string;
+  iana_number?: string;
+  inner?: Record<string, unknown>;
+  name?: string;
+  packets?: number;
+  protocol?: string;
+  transport?: string;
+  type?: string;
+  vlan?: Vlan;
+}
+
+
+interface Vlan {
+  id?: string;
+  name?: string;
+}
+

--- a/generated/observer.ts
+++ b/generated/observer.ts
@@ -1,0 +1,43 @@
+
+export interface EcsObserver {
+  egress?: Record<string, unknown>;
+  geo?: Geo;
+  hostname?: string;
+  ingress?: Record<string, unknown>;
+  ip?: string;
+  mac?: string;
+  name?: string;
+  os?: Os;
+  product?: string;
+  serial_number?: string;
+  type?: string;
+  vendor?: string;
+  version?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Os {
+  family?: string;
+  full?: string;
+  kernel?: string;
+  name?: string;
+  platform?: string;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/orchestrator.ts
+++ b/generated/orchestrator.ts
@@ -1,0 +1,23 @@
+
+export interface EcsOrchestrator {
+  api_version?: string;
+  cluster?: Cluster;
+  namespace?: string;
+  organization?: string;
+  resource?: Resource;
+  type?: string;
+}
+
+
+interface Cluster {
+  name?: string;
+  url?: string;
+  version?: string;
+}
+
+
+interface Resource {
+  name?: string;
+  type?: string;
+}
+

--- a/generated/organization.ts
+++ b/generated/organization.ts
@@ -1,0 +1,6 @@
+
+export interface EcsOrganization {
+  id?: string;
+  name?: string;
+}
+

--- a/generated/os.ts
+++ b/generated/os.ts
@@ -1,0 +1,11 @@
+
+export interface EcsOs {
+  family?: string;
+  full?: string;
+  kernel?: string;
+  name?: string;
+  platform?: string;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/package.ts
+++ b/generated/package.ts
@@ -1,0 +1,17 @@
+
+export interface EcsPackage {
+  architecture?: string;
+  build_version?: string;
+  checksum?: string;
+  description?: string;
+  install_scope?: string;
+  installed?: string;
+  license?: string;
+  name?: string;
+  path?: string;
+  reference?: string;
+  size?: number;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/pe.ts
+++ b/generated/pe.ts
@@ -1,0 +1,12 @@
+
+export interface EcsPe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+

--- a/generated/process.ts
+++ b/generated/process.ts
@@ -1,0 +1,185 @@
+
+export interface EcsProcess {
+  args?: string;
+  args_count?: number;
+  code_signature?: CodeSignature;
+  command_line?: string;
+  elf?: Elf;
+  end?: string;
+  entity_id?: string;
+  executable?: string;
+  exit_code?: number;
+  hash?: Hash;
+  name?: string;
+  parent?: Parent;
+  pe?: Pe;
+  pgid?: number;
+  pid?: number;
+  start?: string;
+  thread?: Thread;
+  title?: string;
+  uptime?: number;
+  working_directory?: string;
+}
+
+
+interface CodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+
+
+interface Elf {
+  architecture?: string;
+  byte_order?: string;
+  cpu_type?: string;
+  creation_date?: string;
+  exports?: Record<string, unknown>;
+  header?: Header;
+  imports?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  segments?: Record<string, unknown>;
+  shared_libraries?: string;
+  telfhash?: string;
+}
+
+
+interface Header {
+  abi_version?: string;
+  class?: string;
+  data?: string;
+  entrypoint?: number;
+  object_version?: string;
+  os_abi?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+
+
+interface Parent {
+  args?: string;
+  args_count?: number;
+  code_signature?: CodeSignature;
+  command_line?: string;
+  elf?: Elf;
+  end?: string;
+  entity_id?: string;
+  executable?: string;
+  exit_code?: number;
+  hash?: Hash;
+  name?: string;
+  pe?: Pe;
+  pgid?: number;
+  pid?: number;
+  start?: string;
+  thread?: Thread;
+  title?: string;
+  uptime?: number;
+  working_directory?: string;
+}
+
+
+interface CodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+
+
+interface Elf {
+  architecture?: string;
+  byte_order?: string;
+  cpu_type?: string;
+  creation_date?: string;
+  exports?: Record<string, unknown>;
+  header?: Header;
+  imports?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  segments?: Record<string, unknown>;
+  shared_libraries?: string;
+  telfhash?: string;
+}
+
+
+interface Header {
+  abi_version?: string;
+  class?: string;
+  data?: string;
+  entrypoint?: number;
+  object_version?: string;
+  os_abi?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+
+
+interface Pe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+
+
+interface Thread {
+  id?: number;
+  name?: string;
+}
+
+
+interface Pe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+
+
+interface Thread {
+  id?: number;
+  name?: string;
+}
+

--- a/generated/registry.ts
+++ b/generated/registry.ts
@@ -1,0 +1,16 @@
+
+export interface EcsRegistry {
+  data?: Data;
+  hive?: string;
+  key?: string;
+  path?: string;
+  value?: string;
+}
+
+
+interface Data {
+  bytes?: string;
+  strings?: string;
+  type?: string;
+}
+

--- a/generated/related.ts
+++ b/generated/related.ts
@@ -1,0 +1,8 @@
+
+export interface EcsRelated {
+  hash?: string;
+  hosts?: string;
+  ip?: string;
+  user?: string;
+}
+

--- a/generated/rule.ts
+++ b/generated/rule.ts
@@ -1,0 +1,14 @@
+
+export interface EcsRule {
+  author?: string;
+  category?: string;
+  description?: string;
+  id?: string;
+  license?: string;
+  name?: string;
+  reference?: string;
+  ruleset?: string;
+  uuid?: string;
+  version?: string;
+}
+

--- a/generated/server.ts
+++ b/generated/server.ts
@@ -1,0 +1,69 @@
+
+export interface EcsServer {
+  address?: string;
+  as?: As;
+  bytes?: number;
+  domain?: string;
+  geo?: Geo;
+  ip?: string;
+  mac?: string;
+  nat?: Nat;
+  packets?: number;
+  port?: number;
+  registered_domain?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  user?: User;
+}
+
+
+interface As {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Nat {
+  ip?: string;
+  port?: number;
+}
+
+
+interface User {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/service.ts
+++ b/generated/service.ts
@@ -1,0 +1,56 @@
+
+export interface EcsService {
+  address?: string;
+  environment?: string;
+  ephemeral_id?: string;
+  id?: string;
+  name?: string;
+  node?: Node;
+  origin?: Origin;
+  state?: string;
+  target?: Target;
+  type?: string;
+  version?: string;
+}
+
+
+interface Node {
+  name?: string;
+}
+
+
+interface Origin {
+  address?: string;
+  environment?: string;
+  ephemeral_id?: string;
+  id?: string;
+  name?: string;
+  node?: Node;
+  state?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Node {
+  name?: string;
+}
+
+
+interface Target {
+  address?: string;
+  environment?: string;
+  ephemeral_id?: string;
+  id?: string;
+  name?: string;
+  node?: Node;
+  state?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Node {
+  name?: string;
+}
+

--- a/generated/source.ts
+++ b/generated/source.ts
@@ -1,0 +1,69 @@
+
+export interface EcsSource {
+  address?: string;
+  as?: As;
+  bytes?: number;
+  domain?: string;
+  geo?: Geo;
+  ip?: string;
+  mac?: string;
+  nat?: Nat;
+  packets?: number;
+  port?: number;
+  registered_domain?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  user?: User;
+}
+
+
+interface As {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Nat {
+  ip?: string;
+  port?: number;
+}
+
+
+interface User {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/threat.ts
+++ b/generated/threat.ts
@@ -1,0 +1,315 @@
+
+export interface EcsThreat {
+  enrichments?: Record<string, unknown>;
+  framework?: string;
+  group?: Group;
+  indicator?: Indicator;
+  software?: Software;
+  tactic?: Tactic;
+  technique?: Technique;
+}
+
+
+interface Group {
+  alias?: string;
+  id?: string;
+  name?: string;
+  reference?: string;
+}
+
+
+interface Indicator {
+  as?: As;
+  confidence?: string;
+  description?: string;
+  email?: Email;
+  file?: File;
+  first_seen?: string;
+  geo?: Geo;
+  ip?: string;
+  last_seen?: string;
+  marking?: Marking;
+  modified_at?: string;
+  port?: number;
+  provider?: string;
+  reference?: string;
+  registry?: Registry;
+  scanner_stats?: number;
+  sightings?: number;
+  type?: string;
+  url?: Url;
+  x509?: X509;
+}
+
+
+interface As {
+  number?: number;
+  organization?: Organization;
+}
+
+
+interface Organization {
+  name?: string;
+}
+
+
+interface Email {
+  address?: string;
+}
+
+
+interface File {
+  accessed?: string;
+  attributes?: string;
+  code_signature?: CodeSignature;
+  created?: string;
+  ctime?: string;
+  device?: string;
+  directory?: string;
+  drive_letter?: string;
+  elf?: Elf;
+  extension?: string;
+  fork_name?: string;
+  gid?: string;
+  group?: string;
+  hash?: Hash;
+  inode?: string;
+  mime_type?: string;
+  mode?: string;
+  mtime?: string;
+  name?: string;
+  owner?: string;
+  path?: string;
+  pe?: Pe;
+  size?: number;
+  target_path?: string;
+  type?: string;
+  uid?: string;
+  x509?: X509;
+}
+
+
+interface CodeSignature {
+  digest_algorithm?: string;
+  exists?: boolean;
+  signing_id?: string;
+  status?: string;
+  subject_name?: string;
+  team_id?: string;
+  timestamp?: string;
+  trusted?: boolean;
+  valid?: boolean;
+}
+
+
+interface Elf {
+  architecture?: string;
+  byte_order?: string;
+  cpu_type?: string;
+  creation_date?: string;
+  exports?: Record<string, unknown>;
+  header?: Header;
+  imports?: Record<string, unknown>;
+  sections?: Record<string, unknown>;
+  segments?: Record<string, unknown>;
+  shared_libraries?: string;
+  telfhash?: string;
+}
+
+
+interface Header {
+  abi_version?: string;
+  class?: string;
+  data?: string;
+  entrypoint?: number;
+  object_version?: string;
+  os_abi?: string;
+  type?: string;
+  version?: string;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+  sha384?: string;
+  sha512?: string;
+  ssdeep?: string;
+  tlsh?: string;
+}
+
+
+interface Pe {
+  architecture?: string;
+  company?: string;
+  description?: string;
+  file_version?: string;
+  imphash?: string;
+  original_file_name?: string;
+  pehash?: string;
+  product?: string;
+}
+
+
+interface X509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Geo {
+  city_name?: string;
+  continent_code?: string;
+  continent_name?: string;
+  country_iso_code?: string;
+  country_name?: string;
+  location?: { lat: number; lon: number };
+  name?: string;
+  postal_code?: string;
+  region_iso_code?: string;
+  region_name?: string;
+  timezone?: string;
+}
+
+
+interface Marking {
+  tlp?: string;
+}
+
+
+interface Registry {
+  data?: Data;
+  hive?: string;
+  key?: string;
+  path?: string;
+  value?: string;
+}
+
+
+interface Data {
+  bytes?: string;
+  strings?: string;
+  type?: string;
+}
+
+
+interface Url {
+  domain?: string;
+  extension?: string;
+  fragment?: string;
+  full?: string;
+  original?: string;
+  password?: string;
+  path?: string;
+  port?: number;
+  query?: string;
+  registered_domain?: string;
+  scheme?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  username?: string;
+}
+
+
+interface X509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Software {
+  alias?: string;
+  id?: string;
+  name?: string;
+  platforms?: string;
+  reference?: string;
+  type?: string;
+}
+
+
+interface Tactic {
+  id?: string;
+  name?: string;
+  reference?: string;
+}
+
+
+interface Technique {
+  id?: string;
+  name?: string;
+  reference?: string;
+  subtechnique?: Subtechnique;
+}
+
+
+interface Subtechnique {
+  id?: string;
+  name?: string;
+  reference?: string;
+}
+

--- a/generated/tls.ts
+++ b/generated/tls.ts
@@ -1,0 +1,131 @@
+
+export interface EcsTls {
+  cipher?: string;
+  client?: Client;
+  curve?: string;
+  established?: boolean;
+  next_protocol?: string;
+  resumed?: boolean;
+  server?: Server;
+  version?: string;
+  version_protocol?: string;
+}
+
+
+interface Client {
+  certificate?: string;
+  certificate_chain?: string;
+  hash?: Hash;
+  issuer?: string;
+  ja3?: string;
+  not_after?: string;
+  not_before?: string;
+  server_name?: string;
+  subject?: string;
+  supported_ciphers?: string;
+  x509?: X509;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+}
+
+
+interface X509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Server {
+  certificate?: string;
+  certificate_chain?: string;
+  hash?: Hash;
+  issuer?: string;
+  ja3s?: string;
+  not_after?: string;
+  not_before?: string;
+  subject?: string;
+  x509?: X509;
+}
+
+
+interface Hash {
+  md5?: string;
+  sha1?: string;
+  sha256?: string;
+}
+
+
+interface X509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+

--- a/generated/tracing.ts
+++ b/generated/tracing.ts
@@ -1,0 +1,4 @@
+
+export interface EcsTracing {
+}
+

--- a/generated/url.ts
+++ b/generated/url.ts
@@ -1,0 +1,18 @@
+
+export interface EcsUrl {
+  domain?: string;
+  extension?: string;
+  fragment?: string;
+  full?: string;
+  original?: string;
+  password?: string;
+  path?: string;
+  port?: number;
+  query?: string;
+  registered_domain?: string;
+  scheme?: string;
+  subdomain?: string;
+  top_level_domain?: string;
+  username?: string;
+}
+

--- a/generated/user.ts
+++ b/generated/user.ts
@@ -1,0 +1,79 @@
+
+export interface EcsUser {
+  changes?: Changes;
+  domain?: string;
+  effective?: Effective;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+  target?: Target;
+}
+
+
+interface Changes {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+
+
+interface Effective {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+
+
+interface Target {
+  domain?: string;
+  email?: string;
+  full_name?: string;
+  group?: Group;
+  hash?: string;
+  id?: string;
+  name?: string;
+  roles?: string;
+}
+
+
+interface Group {
+  domain?: string;
+  id?: string;
+  name?: string;
+}
+

--- a/generated/user_agent.ts
+++ b/generated/user_agent.ts
@@ -1,0 +1,25 @@
+
+export interface EcsUserAgent {
+  device?: Device;
+  name?: string;
+  original?: string;
+  os?: Os;
+  version?: string;
+}
+
+
+interface Device {
+  name?: string;
+}
+
+
+interface Os {
+  family?: string;
+  full?: string;
+  kernel?: string;
+  name?: string;
+  platform?: string;
+  type?: string;
+  version?: string;
+}
+

--- a/generated/vlan.ts
+++ b/generated/vlan.ts
@@ -1,0 +1,6 @@
+
+export interface EcsVlan {
+  id?: string;
+  name?: string;
+}
+

--- a/generated/vulnerability.ts
+++ b/generated/vulnerability.ts
@@ -1,0 +1,27 @@
+
+export interface EcsVulnerability {
+  category?: string;
+  classification?: string;
+  description?: string;
+  enumeration?: string;
+  id?: string;
+  reference?: string;
+  report_id?: string;
+  scanner?: Scanner;
+  score?: Score;
+  severity?: string;
+}
+
+
+interface Scanner {
+  vendor?: string;
+}
+
+
+interface Score {
+  base?: number;
+  environmental?: number;
+  temporal?: number;
+  version?: string;
+}
+

--- a/generated/x509.ts
+++ b/generated/x509.ts
@@ -1,0 +1,38 @@
+
+export interface EcsX509 {
+  alternative_names?: string;
+  issuer?: Issuer;
+  not_after?: string;
+  not_before?: string;
+  public_key_algorithm?: string;
+  public_key_curve?: string;
+  public_key_exponent?: number;
+  public_key_size?: number;
+  serial_number?: string;
+  signature_algorithm?: string;
+  subject?: Subject;
+  version_number?: string;
+}
+
+
+interface Issuer {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+
+
+interface Subject {
+  common_name?: string;
+  country?: string;
+  distinguished_name?: string;
+  locality?: string;
+  organization?: string;
+  organizational_unit?: string;
+  state_or_province?: string;
+}
+

--- a/package.json
+++ b/package.json
@@ -7,19 +7,22 @@
     "generate-ecs-types": "./bin/generate-ecs-types.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf build && tsc",
     "dev": "rm -rf build && tsc --watch",
-    "generate-ecs-types": "node bin/generate-ecs-types.js",
+    "generate-ecs-types": "rm -rf generated/*.ts && node bin/generate-ecs-types.js",
     "test": "jest"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/elastic/ecs-typescript.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/js-yaml": "^4.0.5",
+    "@types/lodash": "^4.14.178",
     "@types/node": "^17.0.11",
     "commander": "^8.3.0",
     "jest": "^27.4.7",

--- a/src/build_types/build_types.test.ts
+++ b/src/build_types/build_types.test.ts
@@ -1,0 +1,89 @@
+import { EcsNestedSpec } from '../types';
+import { buildSpecJson, buildTypes } from './build_types';
+
+const spec = ({
+  a: {
+    description: 'a group description',
+    fields: {
+      a1: {
+        description: 'a1 description',
+        flat_name: 'a.a1',
+        name: 'a1',
+        type: 'long',
+      },
+      'nested.a2': {
+        description: 'a2 description',
+        flat_name: 'a.nested.a2',
+        name: 'a2',
+        type: 'keyword',
+      },
+    },
+  }
+} as unknown) as EcsNestedSpec;
+
+describe('buildSpecJson', () => {
+  it('converts the spec to nested json with spec metadata', () => {
+    expect(buildSpecJson(spec)).toMatchInlineSnapshot(`
+Object {
+  "a": Object {
+    "__description": "a group description",
+    "a1": Object {
+      "__spec": Object {
+        "description": "a1 description",
+        "flat_name": "a.a1",
+        "name": "a1",
+        "type": "long",
+      },
+    },
+    "nested": Object {
+      "a2": Object {
+        "__spec": Object {
+          "description": "a2 description",
+          "flat_name": "a.nested.a2",
+          "name": "a2",
+          "type": "keyword",
+        },
+      },
+    },
+  },
+}
+`);
+  });
+});
+
+describe('buildTypes', () => {
+  it('returns the expected type string', () => {
+    expect(buildTypes(spec)).toMatchInlineSnapshot(`
+Array [
+  Interface {
+    "description": "a group description",
+    "name": "a",
+    "otherInterfaces": Array [],
+    "properties": Object {
+      "a1": Object {
+        "description": "a1 description",
+        "flat_name": "a.a1",
+        "name": "a1",
+        "type": "long",
+      },
+      "nested": Interface {
+        "description": "a group description",
+        "name": "nested",
+        "otherInterfaces": Array [],
+        "properties": Object {
+          "a2": Object {
+            "description": "a2 description",
+            "flat_name": "a.nested.a2",
+            "name": "a2",
+            "type": "keyword",
+          },
+        },
+        "str": "",
+      },
+    },
+    "str": "",
+  },
+]
+`);
+  });
+});

--- a/src/build_types/build_types.ts
+++ b/src/build_types/build_types.ts
@@ -1,15 +1,89 @@
-import { convertType } from './convert_type';
-import { Helpers} from './helpers';
+import { set } from 'lodash';
+import { Interface } from './interface';
+import type { EcsFieldSpec, EcsGroupSpec, EcsNestedSpec } from '../types';
 
-const helper = new Helpers();
+const SPEC_IDENTIFIER = '__spec';
+const DESCRIPTION_IDENTIFIER = '__description';
+const BASE_GROUP_NAME = 'base';
 
-export function buildTypes(spec: Record<string, any>): string {
-  const description = helper.buildDescription(spec?.agent?.description);
-  return `// ECS types
+type SpecJson = Record<string, unknown | SpecInternals>;
+type SpecInternals = {
+  __description?: string;
+  __spec?: EcsFieldSpec;
+};
 
-${description}
-export interface Test {
-  ${spec.agent.fields['agent.name'].name}?: ${convertType(spec.agent.fields['agent.name'].type)};
+function isGroupSpec(spec: unknown): spec is EcsGroupSpec & SpecInternals {
+  return (spec as EcsGroupSpec & SpecInternals)[DESCRIPTION_IDENTIFIER] !== undefined;
 }
-  `;
+
+function isFieldSpec(spec: unknown): spec is EcsFieldSpec {
+  return (
+    (spec as EcsFieldSpec).name !== undefined &&
+    (spec as EcsFieldSpec).type !== undefined
+  );
+}
+
+export function buildSpecJson(spec: EcsNestedSpec): SpecJson {
+  const json: SpecJson = {};
+
+  for (const [group, groupSpec] of Object.entries(spec)) {
+    set(json, group, { [DESCRIPTION_IDENTIFIER]: groupSpec.description });
+    for (const [, fieldSpec] of Object.entries(groupSpec.fields)) {
+      set(json, `${fieldSpec.flat_name}.${SPEC_IDENTIFIER}`, fieldSpec);
+    }
+  }
+
+  return json;
+}
+
+export function buildInterfaceProps(i: Interface, groupName: string, groupProps: SpecJson): void {
+  if (groupProps.hasOwnProperty(SPEC_IDENTIFIER)) {
+    const props = groupProps[SPEC_IDENTIFIER];
+    if (!isFieldSpec(props)) {
+      return;
+    }
+
+    // reached the leaf node; add property
+    i.addProperty(groupName, props);
+    return;
+  }
+
+  // haven't reached a leaf node yet; create a new interface and recurse
+  for (const [nextGroupName, nextGroupProps] of Object.entries(groupProps)) {
+    if (nextGroupName === DESCRIPTION_IDENTIFIER) {
+      continue;
+    }
+    const description = groupProps.hasOwnProperty(DESCRIPTION_IDENTIFIER)
+      ? groupProps[DESCRIPTION_IDENTIFIER] as string
+      : '';
+
+    const nextGroupSpecJson = nextGroupProps as SpecJson;
+    if (nextGroupSpecJson.hasOwnProperty(SPEC_IDENTIFIER)) {
+      // if the next node will be a leaf, skip creating a new interface
+      // and attach to the existing one instead
+      i.addProperty(nextGroupName, (nextGroupSpecJson[SPEC_IDENTIFIER] as EcsFieldSpec));
+      buildInterfaceProps(i, nextGroupName, nextGroupSpecJson);
+    } else {
+      const nextInterface = new Interface({ name: nextGroupName, description });
+      i.addProperty(nextGroupName, nextInterface);
+      buildInterfaceProps(nextInterface, nextGroupName, nextGroupSpecJson);
+    }
+  }
+}
+
+export function buildTypes(spec: EcsNestedSpec): Interface[] {
+  const json = buildSpecJson(spec);
+
+  const interfaces: Interface[] = [];
+  for (const [groupName, groupProps] of Object.entries(json)) {
+    if (!isGroupSpec(groupProps) || groupName === BASE_GROUP_NAME) {
+      // TODO: Need to handle base / root-level fields
+      continue;
+    }
+    const i = new Interface({ description: groupProps[DESCRIPTION_IDENTIFIER] ?? '', name: groupName });
+    buildInterfaceProps(i, groupName, groupProps);
+    interfaces.push(i);
+  }
+
+  return interfaces;
 }

--- a/src/build_types/convert_type.ts
+++ b/src/build_types/convert_type.ts
@@ -5,8 +5,16 @@ const typeMapping: Record<string, string> = {
   date: 'string',
   constant_keyword: 'string',
   float: 'number',
+  scaled_float: 'number',
   long: 'number',
-  boolean: 'boolean'
+  boolean: 'boolean',
+  geo_point: '{ lat: number; lon: number }',
+  ip: 'string',
+  object: 'Record<string, unknown>',
+  flattened: 'Record<string, unknown>',
+  nested: 'Record<string, unknown>',
+  wildcard: 'string',
+  match_only_text: 'string',
 };
 
 export function convertType(ecsType: string): string {

--- a/src/build_types/helpers.test.ts
+++ b/src/build_types/helpers.test.ts
@@ -35,7 +35,7 @@ describe('Helpers', () => {
   
   it('builds an interface property string', () => {
     expect(tester.buildInterfacePropString('my_interface')).toMatchInlineSnapshot(`
-"my_interface?: MyInterface;
+"  my_interface?: MyInterface;
 "
 `)
   });
@@ -55,7 +55,7 @@ describe('Helpers', () => {
       ignore_above: 0
     }
     expect(tester.buildFieldPropString(testFieldSpec)).toMatchInlineSnapshot(`
-"my_prop?: string;
+"  my_prop: string;
 "
 `)
   });

--- a/src/build_types/helpers.ts
+++ b/src/build_types/helpers.ts
@@ -15,18 +15,24 @@ export class Helpers {
   };
   
   public buildDescription(desc: string): string {
+    if (!desc.length) {
+      return '';
+    }
     return desc.split('\n')
       .map((line: string) => `// ${line}`)
       .join('\n');
   };
   
   public buildInterfacePropString(name: string): string {
-    return `${name}?: ${Helpers.asPascalCase(name)};\n`
+    return `  ${name}?: ${Helpers.asPascalCase(name)};\n`
   };
   
   public buildFieldPropString(value: EcsFieldSpec) {
     const { required, name, type } = value;
-    const opt = required === true ? `?` : ``;
-    return `${name}${opt}: ${convertType(type)};\n`;
+    // If the name includes a dot, only use the last part
+    // TODO: handle @timestamp
+    const propName = name.split('.').pop();
+    const opt = required === true ? `` : `?`;
+    return `  ${propName}${opt}: ${convertType(type)};\n`;
   };
 };

--- a/src/build_types/interface.test.ts
+++ b/src/build_types/interface.test.ts
@@ -71,13 +71,15 @@ Interface {
     testMainInterface.addProperty(testProp.name, testInterface);
     const intAsString = testMainInterface.toInterfaceString(true);
     expect(intAsString).toMatchInlineSnapshot(`
-"// main interface
-    export interface EcsMain {
-myinterface_property?: MyinterfaceProperty;
+"
+export interface EcsMain {
+  myinterface_property?: MyinterfaceProperty;
 }
-// My interface property description
-    interface MyinterfaceProperty {
+
+
+interface MyinterfaceProperty {
 }
+
 "
 `)
   });
@@ -118,10 +120,11 @@ Interface {
     testMainInterface.addProperty(testMeta.name, testMeta);
     const intAsString = testMainInterface.toInterfaceString(true);
     expect(intAsString).toMatchInlineSnapshot(`
-"// main interface
-    export interface EcsMain {
-test_prop?: string;
+"
+export interface EcsMain {
+  test_prop: string;
 }
+
 "
 `)
   });
@@ -163,15 +166,17 @@ test_prop?: string;
       account: expect.any(Interface),
     }));
     expect(cloudInterface.toInterfaceString(true)).toMatchInlineSnapshot(`
-"// cloud description
-    export interface EcsCloud {
-availability_zone: string;
-account?: Account;
+"
+export interface EcsCloud {
+  availability_zone?: string;
+  account?: Account;
 }
-// account description
-    interface Account {
-id: string;
+
+
+interface Account {
+  id?: string;
 }
+
 "
 `)
   });

--- a/src/build_types/interface.ts
+++ b/src/build_types/interface.ts
@@ -3,11 +3,11 @@ import { EcsFieldSpec } from '../types';
 
 const h = new Helpers();
 export class Interface {
-  properties: Record<string, Interface | EcsFieldSpec>;
   description: string;
   name: string;
-  str: string;
-  otherInterfaces: Interface[];
+  properties: Record<string, Interface | EcsFieldSpec>;
+  private str: string;
+  private otherInterfaces: Interface[];
   
   constructor(meta: { name: string, description: string }) {
     this.description = meta.description;
@@ -23,10 +23,10 @@ export class Interface {
     }
   };
 
-  toInterfaceString(exportInterface: boolean): string {
-    this.str += h.buildDescription(this.description);
+  toInterfaceString(exportInterface: boolean = true): string {
+    // this.str += h.buildDescription(this.description);
     this.str += `
-    ${h.buildInterfaceName(this.name, exportInterface)}`
+${h.buildInterfaceName(this.name, exportInterface)}`;
     for (const [key, value] of Object.entries(this.properties)) {
       if (this.properties[key] instanceof Interface) {
         this.str += h.buildInterfacePropString(value.name); 
@@ -35,7 +35,7 @@ export class Interface {
         this.str += h.buildFieldPropString(value as EcsFieldSpec);
       }
     }
-    this.str += `}\n`
+    this.str += `}\n\n`;
     this.otherInterfaces.forEach((int: Interface) => this.str += int.toInterfaceString(false))
     return this.str;
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@ import { writeFile } from './write_file';
 
 interface Options {
   spec: string;
-  out: string;
+  dir: string;
 }
 
 function initCommand() {
@@ -20,7 +20,7 @@ function initCommand() {
         'of the Elastic Common Schema (ECS).'
     )
     .option('-s, --spec <path>', 'path to the ecs_nested.yml spec', 'tmp/ecs_nested.yml')
-    .option('-o, --out <path>', 'path where the generated file will be written', 'generated/ecs.ts');
+    .option('-d, --dir <directory>', 'directory where the generated file will be written', 'generated');
 
   program.parse(argv);
 
@@ -31,13 +31,20 @@ export function run() {
   const program = initCommand();
   const options = program.opts() as Options;
 
-  const spec = loadYaml(options.spec);
+  const specPath = path.resolve(__dirname, '..', options.spec)
+  console.log(`Loading ecs_nested.yml from ${specPath}`);
+  const spec = loadYaml(specPath);
   if (!spec) {
     console.error(`Failed to load spec from ${options.spec}`);
     process.exit(1);
   }
 
-  writeFile(path.resolve(__dirname, '..', options.out), buildTypes(spec));
+  const outPath = path.resolve(__dirname, '..', options.dir);
+  const types = buildTypes(spec);
+  for (const type of types) {
+    console.log(`Writing ${type.name} to ${outPath}/${type.name.toLowerCase()}.ts`);
+    writeFile(`${outPath}/${type.name.toLowerCase()}.ts`, type.toInterfaceString(true));
+  }
 
   process.exit(0);
 }

--- a/src/load_yaml.ts
+++ b/src/load_yaml.ts
@@ -4,7 +4,7 @@ import { load } from 'js-yaml';
 
 export function loadYaml(specPath: string) {
   try {
-    const doc = load(fs.readFileSync(path.resolve(__dirname, '..', specPath), 'utf8'));
+    const doc = load(fs.readFileSync(path.resolve(__dirname, '..', '..', specPath), 'utf8'));
     return doc as Record<string, any>;
   } catch (e) {
     console.error(`Failed to load spec from ${specPath}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export type EcsNestedSpec = Record<string, EcsGroupSpec>;
 /**
  * Metadata for each of the top-level items in the EcsSpec.
  */
-export interface EcsGroupSpec {
+export type EcsGroupSpec = {
   description: string;
   fields: Record<string, EcsFieldSpec>;
   footnote?: string;
@@ -19,7 +19,7 @@ export interface EcsGroupSpec {
   short: string;
   title: string;
   type: string;
-}
+};
 
 /**
  * Metadata for each field in a EcsGroupSpec.

--- a/yarn.lock
+++ b/yarn.lock
@@ -562,6 +562,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
   integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
+"@types/lodash@^4.14.178":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
+
 "@types/node@*", "@types/node@^17.0.11":
   version "17.0.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.11.tgz#e0630988ea4c75efde22d5b099360ecfe494160f"
@@ -1851,7 +1856,7 @@ lodash.memoize@4.x:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash@^4.7.0:
+lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Initial implementation of the parsing logic for interpreting the ECS yml and creating the relevant interfaces using the `Interface` class.

With these changes, you should be able to run the CLI and generate files for each of the top-level groups in the ECS schema (that's why the PR is so big... it has all of the generated files)

TODO:
- [x] Parse ECS spec & recursively call `Interface` to handle nested fields
- [x] Write types to individual files in the `generated` directory 
- [x] Fix tests
- [ ] Handle top-level/root fields
- [ ] Handle code comments at the group & property level
- [ ] Autogenerate an index.ts that exports from each of the generated files
- [ ] Special handling for names with special characters (notably `@timestamp` which requires quotes around the property name)
- [ ] More tests / general cleanup
- [ ] Autoformat / prettier (initial implementation: https://github.com/elastic/ecs-typescript/pull/8)