### PR TITLE
Introduce GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Build script
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - run: yarn install --frozen-lockfile
+    - run: yarn test
+    - run: yarn build && yarn generate-ecs-types

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Generate ECS definition package
+
+on:
+  workflow_dispatch:
+    inputs:
+      ecsRef:
+        description: 'ECS Ref'
+        required: false
+        default: 'main'
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'yarn'
+    - run: yarn install --frozen-lockfile
+    - run: yarn build && yarn generate-ecs-types -r ${{ inputs.ecsRef }}
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: New definitions generated from elastic/ecs release ${{ inputs.ecsRef }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build/
 node_modules/
-tmp/
 *.log
 *.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 Automatically generated TypeScript type definitions for the
 [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html).
 
+When run, this program will fetch the ECS schema from the `elastic/ecs` repository. Defaults to `main` ref,
+can be overridden with `--ref` flag.
+
 ## Local development
 
 1. Install yarn & Node.js
-1. Download the latest [ecs_nested.yml](https://github.com/elastic/ecs/raw/main/generated/ecs/ecs_nested.yml) artifact from ECS.
-1. Create a new `tmp/` directory and place the `ecs_nested.yml` in it.
 1. `yarn build`: Runs `tsc`
 1. `yarn dev`: Runs `tsc` and watches for changes
 1. `yarn test`: Runs unit tests with `jest`

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/elastic/ecs-typescript.git"
   },
   "dependencies": {
+    "axios": "^1.2.1",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { loadYaml } from './load_yaml';
 import { outputDefinitions } from './output_definitions';
 
 interface Options {
-  spec: string;
+  ref: string;
   dir: string;
 }
 
@@ -20,9 +20,9 @@ function initCommand() {
         'of the Elastic Common Schema (ECS).'
     )
     .option(
-      '-s, --spec <path>',
-      'path to the ecs_nested.yml spec',
-      'tmp/ecs_nested.yml'
+      '-r, --ref <ref>',
+      'elstic/ecs ref to load ecs_nested.yml spec from',
+      'main'
     )
     .option(
       '-d, --dir <directory>',
@@ -35,20 +35,21 @@ function initCommand() {
   return program;
 }
 
-export function run() {
+export async function run() {
   const program = initCommand();
   const options = program.opts() as Options;
 
-  const specPath = path.resolve(process.cwd(), options.spec);
-  console.log(`Loading ecs_nested.yml from ${specPath}`);
-  const spec = loadYaml(specPath);
-  if (!spec) {
-    console.error(`Failed to load spec from ${options.spec}`);
+  console.log(`Loading ecs_nested.yml from elastic/ecs@${options.ref}`);
+
+  const ref = await loadYaml(options.ref);
+
+  if (!ref) {
+    console.error(`Failed to load spec from ${options.ref}`);
     process.exit(1);
   }
 
   const outPath = path.resolve(process.cwd(), options.dir);
-  const types = buildTypes(spec);
+  const types = buildTypes(ref);
 
   outputDefinitions(types, outPath);
 

--- a/src/load_yaml.ts
+++ b/src/load_yaml.ts
@@ -1,15 +1,21 @@
-import path from 'path';
-import fs from 'fs';
 import { load } from 'js-yaml';
 
-export function loadYaml(specPath: string) {
+import axios from 'axios';
+
+export async function loadYaml(ref: string) {
+  const url = `https://raw.githubusercontent.com/elastic/ecs/${ref}/generated/ecs/ecs_nested.yml`;
+
+  const response = await axios.get<string>(url);
+
+  if (response.status !== 200) {
+    throw new Error(`Could not fetch ecs spec from ${url}`);
+  }
+
   try {
-    const doc = load(
-      fs.readFileSync(path.resolve(__dirname, '..', '..', specPath), 'utf8')
-    );
+    const doc = load(response.data);
     return doc as Record<string, any>;
   } catch (e) {
-    console.error(`Failed to load spec from ${specPath}`);
+    console.error(`Failed to load spec from ${url}`);
     console.error(e);
     process.exit(1);
   }

--- a/src/output_definitions.test.ts
+++ b/src/output_definitions.test.ts
@@ -10,14 +10,14 @@ describe('outputDefinitions()', () => {
   it('should call writeFile', () => {
     outputDefinitions(
       [new Interface({ name: 'base', description: '' })],
-      process.cwd()
+      'output'
     );
 
     expect(writeFile).toHaveBeenCalledTimes(2);
 
     expect(jest.mocked(writeFile).mock.calls[0]).toMatchInlineSnapshot(`
 Array [
-  "/home/luke/projects/ecs-typescript/base.ts",
+  "output/base.ts",
   "
 export interface EcsBase {
 }
@@ -28,7 +28,7 @@ export interface EcsBase {
 
     expect(jest.mocked(writeFile).mock.calls[1]).toMatchInlineSnapshot(`
 Array [
-  "/home/luke/projects/ecs-typescript/index.ts",
+  "output/index.ts",
   "export * from './base';",
 ]
 `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,6 +685,15 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axios@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.1.tgz#44cf04a3c9f0c2252ebd85975361c026cb9f864a"
+  integrity sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 babel-jest@^27.4.6:
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.6.tgz#4d024e69e241cdf4f396e453a07100f44f7ce314"
@@ -1123,10 +1132,24 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.15.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -2084,6 +2107,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"


### PR DESCRIPTION
Initial support for Github Actions with automated specs download from `elastic/ecs` repository (supports versions).

All it does for now is test & build the project & run definition generation (post push);

it also has another action that can be triggered manually (with a webhook later on) and accepts the ECS ref as an input - 
using that ref, it will generate typings and create a new PR with the changes.

I intend to have another action that will handle the release & publish steps later on.