### PR TITLE
Increment minor version during generation pipeline

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -29,6 +29,7 @@ jobs:
         cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - run: yarn build && yarn generate-ecs-types -r ${{ inputs.ecsRef }} && yarn test:integration
+    - run: yarn version --minor
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4
       with:


### PR DESCRIPTION
I figured the package version increment is missing, and should be a part of `generate` pipeline - run after we generate new definitions post ecs update.